### PR TITLE
Add precompiles and test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
@@ -279,7 +279,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-process",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -962,7 +962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -983,8 +983,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.2",
- "crossbeam-utils 0.8.2",
+ "crossbeam-epoch 0.9.3",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -1004,14 +1004,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
  "lazy_static",
- "loom",
  "memoffset 0.6.1",
  "scopeguard",
 ]
@@ -1040,14 +1039,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -1499,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "0.1.0"
-source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#9f307e612efb64e7d680383eb44a5e8b68270c80"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
 dependencies = [
  "derive_more",
  "fp-consensus",
@@ -1522,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#9f307e612efb64e7d680383eb44a5e8b68270c80"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1558,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#9f307e612efb64e7d680383eb44a5e8b68270c80"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",
@@ -1644,7 +1642,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1662,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "0.1.0"
-source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#9f307e612efb64e7d680383eb44a5e8b68270c80"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1673,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "0.8.0"
-source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#9f307e612efb64e7d680383eb44a5e8b68270c80"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
@@ -1686,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "0.1.0"
-source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#9f307e612efb64e7d680383eb44a5e8b68270c80"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1701,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+version = "3.1.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1720,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1743,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1759,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1770,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1796,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1808,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1820,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1830,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1846,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1860,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2075,19 +2073,6 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "generator"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "generic-array"
@@ -2666,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3462,17 +3447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
-dependencies = [
- "cfg-if 1.0.0",
- "generator",
- "scoped-tls",
-]
-
-[[package]]
 name = "lru"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -3771,8 +3745,8 @@ dependencies = [
  "approx",
  "generic-array 0.13.2",
  "matrixmultiply",
- "num-complex",
- "num-rational",
+ "num-complex 0.2.4",
+ "num-rational 0.2.4",
  "num-traits",
  "rand 0.7.3",
  "rand_distr",
@@ -3833,10 +3807,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
+dependencies = [
+ "num-bigint 0.3.1",
+ "num-complex 0.3.1",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.3.2",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3854,6 +3853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3864,13 +3872,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.3.1",
  "num-integer",
  "num-traits",
 ]
@@ -3950,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3968,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3983,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3997,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#9f307e612efb64e7d680383eb44a5e8b68270c80"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4024,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "3.0.0"
-source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#9f307e612efb64e7d680383eb44a5e8b68270c80"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4046,9 +4077,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-evm-precompile-dispatch"
+version = "3.0.0"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
+dependencies = [
+ "evm",
+ "fp-evm",
+ "frame-support",
+ "pallet-evm",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io",
+]
+
+[[package]]
+name = "pallet-evm-precompile-modexp"
+version = "3.0.0"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
+dependencies = [
+ "evm",
+ "fp-evm",
+ "num",
+ "sp-core",
+ "sp-io",
+]
+
+[[package]]
+name = "pallet-evm-precompile-simple"
+version = "3.0.0"
+source = "git+https://github.com/thanhtung6824/frontier.git?branch=v0.1-polka#fe1b4abb92c6970baa806d8f6a977a12849e5669"
+dependencies = [
+ "evm",
+ "fp-evm",
+ "ripemd160",
+ "sp-core",
+ "sp-io",
+]
+
+[[package]]
 name = "pallet-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4069,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4082,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4102,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4129,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4147,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4163,7 +4232,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client 15.1.0",
@@ -4180,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4224,9 +4293,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c823fdae1bb5ff5708ee61a62697e6296175dc671710876871c853f48592b3"
+checksum = "0cd3dab59b5cf4bc81069ade0fc470341a1ef3ad5fa73e5a8943bed2ec12b2e8"
 dependencies = [
  "arrayvec 0.5.2",
  "bitvec",
@@ -4237,9 +4306,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9029e65297c7fd6d7013f0579e193ec2b34ae78eabca854c9417504ad8a2d214"
+checksum = "fa04976a81fde04924b40cc4036c4d12841e8bb04325a5cf2ada75731a150a7d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4676,6 +4745,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
+ "precompiles",
  "serde",
  "sp-api",
  "sp-block-builder",
@@ -4730,6 +4800,20 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "precompiles"
+version = "0.0.1"
+dependencies = [
+ "log",
+ "pallet-evm",
+ "pallet-evm-precompile-dispatch",
+ "pallet-evm-precompile-modexp",
+ "pallet-evm-precompile-simple",
+ "rustc-hex",
+ "sp-core",
+ "sp-std",
+]
 
 [[package]]
 name = "primitive-types"
@@ -5096,7 +5180,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
  "lazy_static",
  "num_cpus",
 ]
@@ -5248,6 +5332,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5297,7 +5392,7 @@ dependencies = [
  "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.2",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -5366,12 +5461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
-
-[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5418,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -5441,7 +5530,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5457,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "impl-trait-for-tuples 0.2.1",
  "parity-scale-codec",
@@ -5478,7 +5567,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5489,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -5527,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5561,7 +5650,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5591,7 +5680,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5602,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -5634,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5642,8 +5731,8 @@ dependencies = [
  "futures-timer 3.0.2",
  "log",
  "merlin",
- "num-bigint",
- "num-rational",
+ "num-bigint 0.2.6",
+ "num-rational 0.2.4",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -5680,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5693,7 +5782,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -5727,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -5753,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5767,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5796,7 +5885,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5812,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5827,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5845,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "dyn-clone",
@@ -5884,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.13",
@@ -5902,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5922,7 +6011,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5941,7 +6030,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5994,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -6010,7 +6099,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6037,7 +6126,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "libp2p",
@@ -6050,7 +6139,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6059,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "hash-db",
@@ -6093,7 +6182,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -6117,7 +6206,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.1.31",
  "jsonrpc-core 15.1.0",
@@ -6135,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "directories",
  "exit-future",
@@ -6198,7 +6287,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6213,7 +6302,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "chrono",
  "futures 0.3.13",
@@ -6235,7 +6324,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6263,7 +6352,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6274,7 +6363,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -6296,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "futures-diagnose",
@@ -6487,9 +6576,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
 dependencies = [
  "itoa",
  "ryu",
@@ -6618,7 +6707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb931b1367faadea6b1ab1c306a860ec17aaa5fa39f367d0c744e69d971a1fb2"
 dependencies = [
  "approx",
- "num-complex",
+ "num-complex 0.2.4",
  "num-traits",
  "paste 0.1.18",
 ]
@@ -6692,7 +6781,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "log",
  "sp-core",
@@ -6704,7 +6793,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6720,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6732,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6744,7 +6833,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6757,7 +6846,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6768,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6780,7 +6869,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "log",
@@ -6798,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "serde",
  "serde_json",
@@ -6807,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -6833,7 +6922,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6848,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6868,7 +6957,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -6878,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6890,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6934,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -6943,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6953,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6964,7 +7053,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6981,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -6993,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "hash-db",
@@ -7017,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7028,7 +7117,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7045,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7055,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "backtrace",
 ]
@@ -7063,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "serde",
  "sp-core",
@@ -7072,7 +7161,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7093,7 +7182,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "impl-trait-for-tuples 0.2.1",
  "parity-scale-codec",
@@ -7110,7 +7199,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7122,7 +7211,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "serde",
  "serde_json",
@@ -7131,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7144,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7154,7 +7243,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "hash-db",
  "log",
@@ -7176,12 +7265,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7194,7 +7283,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "log",
  "sp-core",
@@ -7207,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "impl-trait-for-tuples 0.2.1",
  "parity-scale-codec",
@@ -7221,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7234,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -7250,7 +7339,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7264,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "futures 0.3.13",
  "futures-core",
@@ -7276,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7288,7 +7377,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "impl-trait-for-tuples 0.2.1",
  "parity-scale-codec",
@@ -7409,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "platforms",
 ]
@@ -7417,7 +7506,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.13",
@@ -7440,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7454,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#1febf99d6385ff9ff934a9b16a53234b4858bf5c"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#a6ff3d3be40de2496a705a237483b2c3a541b143"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -8284,9 +8373,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -8294,9 +8383,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -8309,9 +8398,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8321,9 +8410,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8331,9 +8420,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8344,9 +8433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "wasm-gc-api"
@@ -8382,7 +8471,7 @@ checksum = "bf617d864d25af3587aa745529f7aaa541066c876d57e050c0d0c85c61c92aff"
 dependencies = [
  "libc",
  "memory_units",
- "num-rational",
+ "num-rational 0.2.4",
  "num-traits",
  "parity-wasm 0.41.0",
  "wasmi-validation",
@@ -8610,9 +8699,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -5,7 +5,7 @@ use polkafoundry_runtime::{
 };
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_finality_grandpa::AuthorityId as GrandpaId;
-use sp_runtime::traits::{BlakeTwo256, Verify, IdentifyAccount};
+use sp_runtime::traits::{Verify, IdentifyAccount};
 use sc_service::ChainType;
 use std::collections::BTreeMap;
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -35,6 +35,7 @@ frame-system = { default-features = false, git = 'https://github.com/paritytech/
 frame-system-benchmarking = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master', optional = true }
 frame-system-rpc-runtime-api = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master' }
 
+precompiles = { default-features = false, path = 'precompiles/' }
 pallet-aura = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master' }
 pallet-balances = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master' }
 pallet-grandpa = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master' }

--- a/runtime/precompiles/Cargo.toml
+++ b/runtime/precompiles/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = 'precompiles'
+version = '0.0.1'
+authors = ['Polkafoundry']
+edition = '2018'
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = '0.4.8'
+rustc-hex = { version = '2.0.1', default-features = false }
+
+sp-core = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master' }
+sp-std = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master' }
+
+pallet-evm = { default-features = false, git = 'https://github.com/thanhtung6824/frontier.git', branch = 'v0.1-polka' }
+pallet-evm-precompile-dispatch = { default-features = false, git = 'https://github.com/thanhtung6824/frontier.git', branch = 'v0.1-polka' }
+pallet-evm-precompile-modexp = { default-features = false, git = 'https://github.com/thanhtung6824/frontier.git', branch = 'v0.1-polka' }
+pallet-evm-precompile-simple = { default-features = false, git = 'https://github.com/thanhtung6824/frontier.git', branch = 'v0.1-polka' }
+
+[features]
+default = [ "std" ]
+std = [
+    'sp-std/std',
+    'sp-core/std',
+    'pallet-evm-precompile-dispatch/std',
+    'pallet-evm-precompile-modexp/std',
+    'pallet-evm-precompile-simple/std',
+]

--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -1,0 +1,17 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
+use pallet_evm_precompile_dispatch::Dispatch;
+use pallet_evm_precompile_modexp::Modexp;
+
+// TODO: Make other precompiles work ...
+// https://ethereum.stackexchange.com/questions/15479/list-of-pre-compiled-contracts
+
+pub type PolkafoundryPrecompiles<Runtime> = (
+	ECRecover,
+	Sha256,
+	Ripemd160,
+	Identity,
+	Modexp,
+	Dispatch<Runtime>,
+);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -308,7 +308,7 @@ impl pallet_evm::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
-	type Precompiles = ();
+	type Precompiles = precompiles::PolkafoundryPrecompiles<Self>;
 	type ChainId = ChainId;
 }
 

--- a/tests/test/contract-precompiles.test.js
+++ b/tests/test/contract-precompiles.test.js
@@ -1,0 +1,59 @@
+const { customRequest, describeWithPolkafoundry } = require('./utils');
+const { GENESIS_ACCOUNT } = require('./constants');
+const { expect } = require('chai');
+
+describeWithPolkafoundry('Polkafoundry Precompiles', 'polka-spec.json', (context) => {
+    // it.skip('ECR20 should be valid', async () => {
+    //     const message = await context.web3.eth.accounts.sign(context.web3.utils.sha3('Hello world'), GENESIS_ACCOUNT_PRIVATE_KEY);
+    //     const tx = await customRequest(context.web3, 'eth_call', [
+    //         {
+    //             from: GENESIS_ACCOUNT,
+    //             value: '0x00',
+    //             gasPrice: '0x01',
+    //             gas: '0x100000',
+    //             to: '0x0000000000000000000000000000000000000001',
+    //             // data: `0x${Buffer.from(message.messageHash).toString("hex")}`,
+    //         },
+    //     ]);
+    //     console.log('tx_call', tx)
+    //     expect(tx.result).equals(
+    //         '...'
+    //     );
+    //
+    // })
+
+    it('Sha256 should be valid', async () => {
+        const tx = await customRequest(context.web3, 'eth_call', [
+            {
+                from: GENESIS_ACCOUNT,
+                value: '0x00',
+                gasPrice: '0x01',
+                gas: '0x100000',
+                to: '0x0000000000000000000000000000000000000002',
+                data: `0x${Buffer.from('Hello world!').toString('hex')}`,
+            },
+        ]);
+        expect(tx.result).equals(
+            '0xc0535e4be2b79ffd93291305436bf889314e4a3faec05ecffcbb7df31ad9e51a'
+        );
+
+    })
+
+    it('Ripemd160 should be valid', async () => {
+        const tx = await customRequest(context.web3, 'eth_call', [
+            {
+                from: GENESIS_ACCOUNT,
+                value: '0x00',
+                gasPrice: '0x01',
+                gas: '0x100000',
+                to: '0x0000000000000000000000000000000000000003',
+                data: `0x${Buffer.from('Hello world!').toString('hex')}`,
+            },
+        ]);
+
+        expect(tx.result).equals(
+            '0x0000000000000000000000007f772647d88750add82d8e1a7a3e5c0902a346a3'
+        );
+    });
+
+})


### PR DESCRIPTION
Include five precompiles: ECRecover, Sha256, Ripemd160, Identity, Modexp

We need to support more in the future and add more tests