### PR TITLE
Add & Test EVM precompile sha3fips & curve25519

### DIFF
--- a/runtime/precompiles/Cargo.toml
+++ b/runtime/precompiles/Cargo.toml
@@ -17,6 +17,7 @@ pallet-evm = { default-features = false, git = 'https://github.com/polkafoundry/
 pallet-evm-precompile-dispatch = { default-features = false, git = 'https://github.com/polkafoundry/frontier.git', branch = 'halongbay' }
 pallet-evm-precompile-modexp = { default-features = false, git = 'https://github.com/polkafoundry/frontier.git', branch = 'halongbay' }
 pallet-evm-precompile-simple = { default-features = false, git = 'https://github.com/polkafoundry/frontier.git', branch = 'halongbay' }
+pallet-evm-precompile-sha3fips = { default-features = false, git = 'https://github.com/polkafoundry/frontier.git', branch = 'halongbay' }
 
 [features]
 default = [ "std" ]
@@ -26,4 +27,5 @@ std = [
     'pallet-evm-precompile-dispatch/std',
     'pallet-evm-precompile-modexp/std',
     'pallet-evm-precompile-simple/std',
+    'pallet-evm-precompile-sha3fips/std',
 ]

--- a/runtime/precompiles/Cargo.toml
+++ b/runtime/precompiles/Cargo.toml
@@ -18,6 +18,7 @@ pallet-evm-precompile-dispatch = { default-features = false, git = 'https://gith
 pallet-evm-precompile-modexp = { default-features = false, git = 'https://github.com/polkafoundry/frontier.git', branch = 'halongbay' }
 pallet-evm-precompile-simple = { default-features = false, git = 'https://github.com/polkafoundry/frontier.git', branch = 'halongbay' }
 pallet-evm-precompile-sha3fips = { default-features = false, git = 'https://github.com/polkafoundry/frontier.git', branch = 'halongbay' }
+pallet-evm-precompile-curve25519 = { default-features = false, git = 'https://github.com/polkafoundry/frontier.git', branch = 'halongbay' }
 
 [features]
 default = [ "std" ]
@@ -28,4 +29,5 @@ std = [
     'pallet-evm-precompile-modexp/std',
     'pallet-evm-precompile-simple/std',
     'pallet-evm-precompile-sha3fips/std',
+    'pallet-evm-precompile-curve25519/std',
 ]

--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -5,6 +5,8 @@ use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_sha3fips::Sha3FIPS512;
+use pallet_evm_precompile_curve25519::Curve25519Add;
+use pallet_evm_precompile_curve25519::Curve25519ScalarMul;
 // TODO: Make other precompiles work ...
 // https://ethereum.stackexchange.com/questions/15479/list-of-pre-compiled-contracts
 
@@ -17,4 +19,6 @@ pub type PolkafoundryPrecompiles<Runtime> = (
 	Dispatch<Runtime>,
 	Sha3FIPS256,
 	Sha3FIPS512,
+	Curve25519Add,
+	Curve25519ScalarMul,
 );

--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -3,7 +3,8 @@
 use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
 use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
-
+use pallet_evm_precompile_sha3fips::Sha3FIPS256;
+use pallet_evm_precompile_sha3fips::Sha3FIPS512;
 // TODO: Make other precompiles work ...
 // https://ethereum.stackexchange.com/questions/15479/list-of-pre-compiled-contracts
 
@@ -14,4 +15,6 @@ pub type PolkafoundryPrecompiles<Runtime> = (
 	Identity,
 	Modexp,
 	Dispatch<Runtime>,
+	Sha3FIPS256,
+	Sha3FIPS512,
 );

--- a/tests/test/contract-precompiles.test.js
+++ b/tests/test/contract-precompiles.test.js
@@ -56,4 +56,38 @@ describeWithPolkafoundry('Polkafoundry Precompiles', 'polka-spec.json', (context
         );
     });
 
+    it('Sha3FIPS256 should be valid', async () => {
+        const tx = await customRequest(context.web3, 'eth_call', [
+            {
+                from: GENESIS_ACCOUNT,
+                value: '0x00',
+                gasPrice: '0x01',
+                gas: '0x100000',
+                to: '0x0000000000000000000000000000000000000007',
+                data: `0x${Buffer.from('hello').toString('hex')}`,
+            },
+        ]);
+
+        expect(tx.result).equals(
+            '0x3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392'
+        );
+    });
+
+    it('Sha3FIPS512 should be valid', async () => {
+        const tx = await customRequest(context.web3, 'eth_call', [
+            {
+                from: GENESIS_ACCOUNT,
+                value: '0x00',
+                gasPrice: '0x01',
+                gas: '0x100000',
+                to: '0x0000000000000000000000000000000000000008',
+                data: `0x${Buffer.from('hello').toString('hex')}`,
+            },
+        ]);
+
+        expect(tx.result).equals(
+            '0x75d527c368f2efe848ecf6b073a36767800805e9eef2b1857d5f984f036eb6df891d75f72d9b154518c1cd58835286d1da9a38deba3de98b5a53e5ed78a84976'
+        );
+    });
+
 })


### PR DESCRIPTION
Add the precompile sha3flips
```
$ mocha ./test/contract-precompiles.test.js


  Polkafoundry Precompiles
    ✓ Sha256 should be valid
    ✓ Ripemd160 should be valid
    ✓ Sha3FIPS256 should be valid
    ✓ Sha3FIPS512 should be valid


  4 passing (2s)

✨  Done in 2.96s.
```